### PR TITLE
#6 Change Script Status when editing an existing script

### DIFF
--- a/Library/CommonScripts/CustomComponent/ScriptListBox/ScriptItem.cs
+++ b/Library/CommonScripts/CustomComponent/ScriptListBox/ScriptItem.cs
@@ -100,6 +100,7 @@ namespace CommonScripts.CustomComponent.ScriptListBox
             if (hasScriptTypeChanged)
             {
                 ScriptTypeChanged(editScript);
+                PaintScriptStatus();
             }
             Script = editScript;
             return hasNameBeenModified;

--- a/Library/CommonScripts/Model/Pojo/Base/ScriptAbs.cs
+++ b/Library/CommonScripts/Model/Pojo/Base/ScriptAbs.cs
@@ -31,8 +31,9 @@ namespace CommonScripts.Model.Pojo.Base
 
         object ICloneable.Clone() => Clone();
 
-        public static ScriptAbs GetInstance(ScriptAbs oldScript, ScriptType scriptType, bool hasScriptTypeChanged)
+        public static ScriptAbs GetInstance(ScriptAbs oldScript, ScriptType scriptType)
         {
+            bool hasScriptTypeChanged = oldScript != null && HasScriptTypeChanged(oldScript.ScriptType, scriptType);
             ScriptAbs newScript = null;
             if (oldScript == null || hasScriptTypeChanged)
             {
@@ -58,5 +59,6 @@ namespace CommonScripts.Model.Pojo.Base
 
             return newScript != null ? newScript : oldScript;
         }
+        public static bool HasScriptTypeChanged(ScriptType oldScriptType, ScriptType newScriptType) => oldScriptType != newScriptType;
     }
 }

--- a/Library/CommonScripts/Presenter/Interfaces/IMainPresenter.cs
+++ b/Library/CommonScripts/Presenter/Interfaces/IMainPresenter.cs
@@ -7,7 +7,7 @@ namespace CommonScripts.Presenter.Interfaces
     {
         void LoadSettings();
         bool AddScript(ScriptAbs script);
-        bool EditScript(ScriptAbs script);
+        bool EditScript(ScriptAbs script, bool hasScriptTypeChanged);
         bool RemoveScript(string scriptId);
         Task<bool> ChangeScriptStatus(ScriptAbs script);
         void DoNotAskAgainRunAtStartup();

--- a/Library/CommonScripts/Presenter/MainPresenter.cs
+++ b/Library/CommonScripts/Presenter/MainPresenter.cs
@@ -161,7 +161,7 @@ namespace CommonScripts.Presenter
             _scripts.Add(script);
             return _settingsService.SaveScripts(_scripts);
         }
-        public bool EditScript(ScriptAbs script)
+        public bool EditScript(ScriptAbs script, bool hasScriptTypeChanged)
         {
             Log.Debug("Editing Script {@ScriptName} ({@ScriptType})", script.ScriptName, script.ScriptType);
             bool successful = false;
@@ -169,6 +169,14 @@ namespace CommonScripts.Presenter
             {
                 _scripts.Add(script);
                 successful = _settingsService.SaveScripts(_scripts);
+                if (successful && script.ScriptStatus == ScriptStatus.Running && hasScriptTypeChanged)
+                {
+                    _runScriptService.StopScript(script);
+                    if (script.ScriptType != ScriptType.OneOff)
+                        _runScriptService.RunScript(script);
+                    else
+                        _view.ChangeScriptStatusThreadSafe(script);
+                }
             }
             return successful;
         }

--- a/Library/CommonScripts/View/MainForm.cs
+++ b/Library/CommonScripts/View/MainForm.cs
@@ -44,7 +44,7 @@ namespace CommonScripts.View
         }
         private void AddScript(object sender, EventArgs e)
         {
-            ShowScriptForm(null, (ScriptAbs addedScript, bool hasScriptTypeChanged /*Unused, just used when editting*/) => {
+            ShowScriptForm(null, (ScriptAbs addedScript) => {
                 if (Presenter.AddScript(addedScript))
                 {
                     _scriptListAdapter.AddItem(addedScript);
@@ -53,8 +53,9 @@ namespace CommonScripts.View
         }
         private void EditScript(ScriptAbs script)
         {
-            ShowScriptForm(script, (ScriptAbs editedScript, bool hasScriptTypeChanged) => {
-                if (Presenter.EditScript(editedScript))
+            ShowScriptForm(script, (ScriptAbs editedScript) => {
+                bool hasScriptTypeChanged = script != null && ScriptAbs.HasScriptTypeChanged(script.ScriptType, editedScript.ScriptType);
+                if (Presenter.EditScript(editedScript, hasScriptTypeChanged))
                 {
                     _scriptListAdapter.EditItem(editedScript, hasScriptTypeChanged);
                 }
@@ -122,13 +123,12 @@ namespace CommonScripts.View
         #endregion
 
         #region Private Methods
-        private void ShowScriptForm(ScriptAbs script, Action<ScriptAbs, bool> postAction)
+        private void ShowScriptForm(ScriptAbs script, Action<ScriptAbs> postAction)
         {
             ScriptForm scriptForm = new ScriptForm(styleManager, script);
             if (scriptForm.ShowDialog() == DialogResult.OK)
             {
-                bool hasScriptTypeChanged = script != null && scriptForm.HasScriptTypeChanged;
-                postAction(scriptForm.GetScript(), hasScriptTypeChanged);
+                postAction(scriptForm.GetScript());
             }
         }
         private void InitScriptListAdapter()

--- a/Library/CommonScripts/View/ScriptForm.cs
+++ b/Library/CommonScripts/View/ScriptForm.cs
@@ -13,8 +13,6 @@ namespace CommonScripts.View
 {
     public partial class ScriptForm : MetroSetForm
     {
-        public bool HasScriptTypeChanged { get; internal set; }
-
         private ScriptAbs _script;
         private bool _listeningKeys = false;
 
@@ -48,12 +46,11 @@ namespace CommonScripts.View
         private void Save(object sender, EventArgs e)
         {
             ScriptType scriptType = EnumUtils.ParseOrDefault<ScriptType>(cbxScriptType.SelectedValue);
-
-            HasScriptTypeChanged = _script != null && (scriptType != _script.ScriptType);
-            _script = ScriptAbs.GetInstance(_script, scriptType, HasScriptTypeChanged);
+            ScriptStatus scriptStatus = _script?.ScriptStatus ?? ScriptStatus.Stopped;
+            _script = ScriptAbs.GetInstance(_script, scriptType);
             _script.ScriptName = tbxScriptName.Text;
             _script.ScriptPath = tbxScriptPath.Text;
-            _script.ScriptStatus = ScriptStatus.Stopped;
+            _script.ScriptStatus = scriptStatus;
 
             switch (scriptType)
             {


### PR DESCRIPTION
Everytime the script was edited, the status was set to Stopped. 
Also, due to recreating the Script object, the status was not being refreshed in the UI.
Additional changes: created a static method to check if script status is different into the ScriptAbs class, and so using it when necessary, instead of passing a boolean through methods (when possible).