### PR TITLE
Issues/3/appconfig installer

### DIFF
--- a/Library/CommonScripts/Model/Repository/SettingsRepository.cs
+++ b/Library/CommonScripts/Model/Repository/SettingsRepository.cs
@@ -11,7 +11,6 @@ namespace CommonScripts.Model.Repository
     public class SettingsRepository : ISettingsRepository
     {
         private const string ScriptFile = "scripts.json";
-        private const string SettingsFile = "settings.json";
 
         public SettingsRepository()
         {
@@ -36,7 +35,7 @@ namespace CommonScripts.Model.Repository
                 {
                     TypeNameHandling = TypeNameHandling.All
                 });
-                File.WriteAllText(fileName, json);
+                File.WriteAllText(FileUtils.GetAbsolutePath(fileName), json);
             }
             catch (Exception e)
             {

--- a/Library/CommonScripts/Model/Service/Job/RunScriptJob.cs
+++ b/Library/CommonScripts/Model/Service/Job/RunScriptJob.cs
@@ -1,4 +1,5 @@
 ﻿using CommonScripts.Model.Pojo.Base;
+using CommonScripts.Settings;
 using CommonScripts.Utils;
 using Quartz;
 using Serilog;
@@ -31,7 +32,8 @@ namespace CommonScripts.Model.Service.Job
             if (File.Exists(realPath))
             {
                 Log.Information("Executing {@ScriptName}", _script.ScriptName);
-                string psScript = File.ReadAllText(realPath);
+                string psScript = "Set-Location \"" + AppSettingsManager.GetProjectInstallationPath() + "\"\r\n";
+                psScript += File.ReadAllText(realPath);
                 var powerShell = PowerShell.Create().AddScript(psScript);
                 powerShell.Invoke();
             } else

--- a/Library/CommonScripts/Presenter/Interfaces/IMainPresenter.cs
+++ b/Library/CommonScripts/Presenter/Interfaces/IMainPresenter.cs
@@ -6,6 +6,8 @@ namespace CommonScripts.Presenter.Interfaces
 {
     public interface IMainPresenter
     {
+        bool AppConfigExists();
+        void InitializeAppConfig(string installationPath);
         void LoadScripts();
         void LoadSettings();
         bool AddScript(ScriptAbs script);

--- a/Library/CommonScripts/Presenter/MainPresenter.cs
+++ b/Library/CommonScripts/Presenter/MainPresenter.cs
@@ -229,6 +229,14 @@ namespace CommonScripts.Presenter
             AppSettingsManager.SaveSettings(settings);
             return true;
         }
+        public bool AppConfigExists()
+        {
+            return AppSettingsManager.AppConfigExists();
+        }
+        public void InitializeAppConfig(string installationPath)
+        {
+            AppSettingsManager.CreateAppConfig(installationPath);
+        }
         #endregion
     }
 }

--- a/Library/CommonScripts/Settings/AppSettingsManager.cs
+++ b/Library/CommonScripts/Settings/AppSettingsManager.cs
@@ -9,70 +9,75 @@ namespace CommonScripts.Settings
     public static class AppSettingsManager
     {
         private const string APP_CONFIG_NAME = "app.config";
+        private const string APP_SETTINGS_SECTION = "appSettings";
+        private const string SETTING_INSTALLATION_PATH = "installationPath";
+        private const string SETTING_DO_NOT_ASK_RUN_STARTUP = "doNotAskAgainRunStartup";
+        private const string SETTING_DARK_MODE = "isDarkMode";
+        private const string SETTING_FILE_MIN_LOG_LEVEL = "fileMinimumLoggingLevel";
+        private const string SETTING_CONSOLE_MIN_LOG_LEVEL = "consoleMinimumLoggingLevel";
+        private const string FALSE_BOOL_STRING = "false";
+
         private static AppSettings _settings;
         private static Configuration GetAppConfigFile()
         {
             ExeConfigurationFileMap map = new ExeConfigurationFileMap { ExeConfigFilename = APP_CONFIG_NAME };
             return  ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
         }
-
         public static string GetProjectInstallationPath()
         {
             if (_settings != null)
                 return _settings.InstallationPath;
-            return GetSetting("installationPath").ToString();
+            return GetSetting(SETTING_INSTALLATION_PATH).ToString();
         }
         public static bool AskToRunAppAtStartup()
         {
             if (_settings != null)
                 return _settings.DoNotAskAgainRunStartup;
-            return bool.Parse(GetSetting("doNotAskAgainRunStartup").ToString());
+            return bool.Parse(GetSetting(SETTING_DO_NOT_ASK_RUN_STARTUP).ToString());
         }
         public static bool IsDarkMode()
         {
             if (_settings != null)
                 return _settings.IsDarkMode;
-            return bool.Parse(GetSetting("isDarkMode")?.ToString() ?? "false");
+            return bool.Parse(GetSetting(SETTING_DARK_MODE)?.ToString() ?? FALSE_BOOL_STRING);
         }
         public static LogEventLevel GetFileMinLogLevel()
         {
             if (_settings != null)
                 return _settings.FileMinimumLoggingLevel;
-            return EnumUtils.Parse<LogEventLevel>(GetSetting("fileMinimumLoggingLevel"));
+            return EnumUtils.Parse<LogEventLevel>(GetSetting(SETTING_FILE_MIN_LOG_LEVEL));
         }
         public static LogEventLevel GetConsoleMinLogLevel()
         {
             if (_settings != null)
                 return _settings.ConsoleMinimumLoggingLevel;
-            return EnumUtils.Parse<LogEventLevel>(GetSetting("consoleMinimumLoggingLevel"));
+            return EnumUtils.Parse<LogEventLevel>(GetSetting(SETTING_CONSOLE_MIN_LOG_LEVEL));
         }
-
         public static void SetInstallationPath(string installationPath)
         {
-            SetSettingValue("installationPath", installationPath);
+            SetSettingValue(SETTING_INSTALLATION_PATH, installationPath);
             _settings.InstallationPath = installationPath;
         }
         public static void SetAskToRunAppAtStartup(bool runAtStartup)
         {
-            SetSettingValue("doNotAskAgainRunStartup", runAtStartup.ToString());
+            SetSettingValue(SETTING_DO_NOT_ASK_RUN_STARTUP, runAtStartup.ToString());
             _settings.DoNotAskAgainRunStartup = runAtStartup;
         }
         public static void SetIsDarkMode(bool isDarkMode)
         {
-            SetSettingValue("isDarkMode", isDarkMode.ToString());
+            SetSettingValue(SETTING_DARK_MODE, isDarkMode.ToString());
             _settings.IsDarkMode = isDarkMode;
         }
         public static void SetFileMinLogLevel(LogEventLevel minLogLevel)
         {
-            SetSettingValue("fileMinimumLoggingLevel", minLogLevel.NameToString());
+            SetSettingValue(SETTING_FILE_MIN_LOG_LEVEL, minLogLevel.NameToString());
             _settings.FileMinimumLoggingLevel = minLogLevel;
         }
         public static void SetConsoleMinLogLevel(LogEventLevel minLogLevel)
         {
-            SetSettingValue("consoleMinimumLoggingLevel", minLogLevel.NameToString());
+            SetSettingValue(SETTING_CONSOLE_MIN_LOG_LEVEL, minLogLevel.NameToString());
             _settings.ConsoleMinimumLoggingLevel = minLogLevel;
         }
-
         private static void SetSettingValue(string key, string value)
         {
             Configuration configuration = GetAppConfigFile();
@@ -82,13 +87,12 @@ namespace CommonScripts.Settings
                 configuration.AppSettings.Settings.Add(key, value);
             configuration.Save();
 
-            ConfigurationManager.RefreshSection("appSettings");
+            ConfigurationManager.RefreshSection(APP_SETTINGS_SECTION);
         }
         private static object GetSetting(string key)
         {
             return GetAppConfigFile().AppSettings.Settings[key]?.Value;
         }
-
         public static void LoadSettings()
         {
             _settings = new AppSettings(GetProjectInstallationPath(), IsDarkMode(), AskToRunAppAtStartup(), GetConsoleMinLogLevel(), GetFileMinLogLevel());
@@ -99,7 +103,6 @@ namespace CommonScripts.Settings
                 LoadSettings();
             return _settings;
         }
-
         public static void SaveSettings(AppSettings settings)
         {
             SetAskToRunAppAtStartup(settings.DoNotAskAgainRunStartup);

--- a/Library/CommonScripts/View/MainForm.cs
+++ b/Library/CommonScripts/View/MainForm.cs
@@ -33,6 +33,14 @@ namespace CommonScripts.View
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
+            if (!Presenter.AppConfigExists())
+            {
+                SetInstallationPathForm installationPathForm = new SetInstallationPathForm(styleManager);
+                if (installationPathForm.ShowDialog() == DialogResult.OK)
+                {
+                    Presenter.InitializeAppConfig(installationPathForm.InstallationPath);
+                }
+            }
             Presenter.LoadSettings();
             ReloadStyles(AppSettingsManager.IsDarkMode());
             Presenter.LoadScripts();

--- a/Library/CommonScripts/View/SetInstallationPathForm.Designer.cs
+++ b/Library/CommonScripts/View/SetInstallationPathForm.Designer.cs
@@ -1,0 +1,199 @@
+﻿
+using System;
+
+namespace CommonScripts.View
+{
+    partial class SetInstallationPathForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.btnSave = new MetroSet_UI.Controls.MetroSetButton();
+            this.btnCancel = new MetroSet_UI.Controls.MetroSetButton();
+            this.lblInstallationPath = new MetroSet_UI.Controls.MetroSetLabel();
+            this.btnInstallationPath = new MetroSet_UI.Controls.MetroSetButton();
+            this.tbxInstallationPath = new MetroSet_UI.Controls.MetroSetTextBox();
+            this.fbdInstallationPath = new System.Windows.Forms.FolderBrowserDialog();
+            this.SuspendLayout();
+            // 
+            // btnSave
+            // 
+            this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSave.DisabledBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnSave.DisabledBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnSave.DisabledForeColor = System.Drawing.Color.Gray;
+            this.btnSave.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnSave.HoverBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(95)))), ((int)(((byte)(207)))), ((int)(((byte)(255)))));
+            this.btnSave.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(95)))), ((int)(((byte)(207)))), ((int)(((byte)(255)))));
+            this.btnSave.HoverTextColor = System.Drawing.Color.White;
+            this.btnSave.IsDerivedStyle = true;
+            this.btnSave.Location = new System.Drawing.Point(560, 140);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.NormalBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnSave.NormalColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnSave.NormalTextColor = System.Drawing.Color.White;
+            this.btnSave.PressBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(35)))), ((int)(((byte)(147)))), ((int)(((byte)(195)))));
+            this.btnSave.PressColor = System.Drawing.Color.FromArgb(((int)(((byte)(35)))), ((int)(((byte)(147)))), ((int)(((byte)(195)))));
+            this.btnSave.PressTextColor = System.Drawing.Color.White;
+            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.Style = MetroSet_UI.Enums.Style.Light;
+            this.btnSave.StyleManager = null;
+            this.btnSave.TabIndex = 7;
+            this.btnSave.Text = "Save";
+            this.btnSave.ThemeAuthor = "Narwin";
+            this.btnSave.ThemeName = "MetroLite";
+            this.btnSave.Click += new System.EventHandler(this.Save);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DisabledBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnCancel.DisabledBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnCancel.DisabledForeColor = System.Drawing.Color.Gray;
+            this.btnCancel.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnCancel.HoverBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(95)))), ((int)(((byte)(207)))), ((int)(((byte)(255)))));
+            this.btnCancel.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(95)))), ((int)(((byte)(207)))), ((int)(((byte)(255)))));
+            this.btnCancel.HoverTextColor = System.Drawing.Color.White;
+            this.btnCancel.IsDerivedStyle = true;
+            this.btnCancel.Location = new System.Drawing.Point(479, 140);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.NormalBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnCancel.NormalColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnCancel.NormalTextColor = System.Drawing.Color.White;
+            this.btnCancel.PressBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(35)))), ((int)(((byte)(147)))), ((int)(((byte)(195)))));
+            this.btnCancel.PressColor = System.Drawing.Color.FromArgb(((int)(((byte)(35)))), ((int)(((byte)(147)))), ((int)(((byte)(195)))));
+            this.btnCancel.PressTextColor = System.Drawing.Color.White;
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Style = MetroSet_UI.Enums.Style.Light;
+            this.btnCancel.StyleManager = null;
+            this.btnCancel.TabIndex = 6;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.ThemeAuthor = "Narwin";
+            this.btnCancel.ThemeName = "MetroLite";
+            this.btnCancel.Click += new System.EventHandler(this.Cancel);
+            // 
+            // lblInstallationPath
+            // 
+            this.lblInstallationPath.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblInstallationPath.IsDerivedStyle = true;
+            this.lblInstallationPath.Location = new System.Drawing.Point(15, 95);
+            this.lblInstallationPath.Name = "lblInstallationPath";
+            this.lblInstallationPath.Size = new System.Drawing.Size(100, 26);
+            this.lblInstallationPath.Style = MetroSet_UI.Enums.Style.Light;
+            this.lblInstallationPath.StyleManager = null;
+            this.lblInstallationPath.TabIndex = 2;
+            this.lblInstallationPath.Text = "Path:";
+            this.lblInstallationPath.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblInstallationPath.ThemeAuthor = "Narwin";
+            this.lblInstallationPath.ThemeName = "MetroLite";
+            // 
+            // btnInstallationPath
+            // 
+            this.btnInstallationPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnInstallationPath.DisabledBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnInstallationPath.DisabledBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnInstallationPath.DisabledForeColor = System.Drawing.Color.Gray;
+            this.btnInstallationPath.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnInstallationPath.HoverBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(95)))), ((int)(((byte)(207)))), ((int)(((byte)(255)))));
+            this.btnInstallationPath.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(95)))), ((int)(((byte)(207)))), ((int)(((byte)(255)))));
+            this.btnInstallationPath.HoverTextColor = System.Drawing.Color.White;
+            this.btnInstallationPath.IsDerivedStyle = true;
+            this.btnInstallationPath.Location = new System.Drawing.Point(609, 95);
+            this.btnInstallationPath.Name = "btnInstallationPath";
+            this.btnInstallationPath.NormalBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnInstallationPath.NormalColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(177)))), ((int)(((byte)(225)))));
+            this.btnInstallationPath.NormalTextColor = System.Drawing.Color.White;
+            this.btnInstallationPath.PressBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(35)))), ((int)(((byte)(147)))), ((int)(((byte)(195)))));
+            this.btnInstallationPath.PressColor = System.Drawing.Color.FromArgb(((int)(((byte)(35)))), ((int)(((byte)(147)))), ((int)(((byte)(195)))));
+            this.btnInstallationPath.PressTextColor = System.Drawing.Color.White;
+            this.btnInstallationPath.Size = new System.Drawing.Size(26, 26);
+            this.btnInstallationPath.Style = MetroSet_UI.Enums.Style.Light;
+            this.btnInstallationPath.StyleManager = null;
+            this.btnInstallationPath.TabIndex = 4;
+            this.btnInstallationPath.Text = "...";
+            this.btnInstallationPath.ThemeAuthor = "Narwin";
+            this.btnInstallationPath.ThemeName = "MetroLite";
+            this.btnInstallationPath.Click += new System.EventHandler(this.ShowPathSelector);
+            // 
+            // tbxInstallationPath
+            // 
+            this.tbxInstallationPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbxInstallationPath.AutoCompleteCustomSource = null;
+            this.tbxInstallationPath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.None;
+            this.tbxInstallationPath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.None;
+            this.tbxInstallationPath.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(155)))), ((int)(((byte)(155)))), ((int)(((byte)(155)))));
+            this.tbxInstallationPath.DisabledBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(204)))), ((int)(((byte)(204)))), ((int)(((byte)(204)))));
+            this.tbxInstallationPath.DisabledBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(155)))), ((int)(((byte)(155)))), ((int)(((byte)(155)))));
+            this.tbxInstallationPath.DisabledForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(136)))), ((int)(((byte)(136)))), ((int)(((byte)(136)))));
+            this.tbxInstallationPath.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.tbxInstallationPath.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(102)))), ((int)(((byte)(102)))), ((int)(((byte)(102)))));
+            this.tbxInstallationPath.Image = null;
+            this.tbxInstallationPath.IsDerivedStyle = true;
+            this.tbxInstallationPath.Lines = null;
+            this.tbxInstallationPath.Location = new System.Drawing.Point(121, 95);
+            this.tbxInstallationPath.MaxLength = 32767;
+            this.tbxInstallationPath.Multiline = false;
+            this.tbxInstallationPath.Name = "tbxInstallationPath";
+            this.tbxInstallationPath.ReadOnly = false;
+            this.tbxInstallationPath.Size = new System.Drawing.Size(482, 26);
+            this.tbxInstallationPath.Style = MetroSet_UI.Enums.Style.Light;
+            this.tbxInstallationPath.StyleManager = null;
+            this.tbxInstallationPath.TabIndex = 5;
+            this.tbxInstallationPath.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            this.tbxInstallationPath.ThemeAuthor = "Narwin";
+            this.tbxInstallationPath.ThemeName = "MetroLite";
+            this.tbxInstallationPath.UseSystemPasswordChar = false;
+            this.tbxInstallationPath.WatermarkText = "";
+            // 
+            // SetInstallationPathForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(650, 178);
+            this.Controls.Add(this.tbxInstallationPath);
+            this.Controls.Add(this.btnInstallationPath);
+            this.Controls.Add(this.lblInstallationPath);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnSave);
+            this.MaximumSize = new System.Drawing.Size(1000, 178);
+            this.MinimumSize = new System.Drawing.Size(450, 178);
+            this.Name = "SetInstallationPathForm";
+            this.Text = "Set Installation Path";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private MetroSet_UI.Controls.MetroSetButton btnSave;
+        private MetroSet_UI.Controls.MetroSetButton btnCancel;
+        private MetroSet_UI.Controls.MetroSetLabel lblInstallationPath;
+        private MetroSet_UI.Controls.MetroSetButton btnInstallationPath;
+        private MetroSet_UI.Controls.MetroSetTextBox tbxInstallationPath;
+        private System.Windows.Forms.FolderBrowserDialog fbdInstallationPath;
+    }
+}

--- a/Library/CommonScripts/View/SetInstallationPathForm.cs
+++ b/Library/CommonScripts/View/SetInstallationPathForm.cs
@@ -1,0 +1,34 @@
+﻿using CommonScripts.View.Base;
+using MetroSet_UI.Components;
+using System;
+using System.Windows.Forms;
+
+namespace CommonScripts.View
+{
+    public partial class SetInstallationPathForm : BaseInnerForm
+    {
+        public string InstallationPath { get; private set; }
+        public SetInstallationPathForm(StyleManager styleManager) : base()
+        {
+            InitializeComponent();
+            UpdateMetroStyles(styleManager);
+        }
+
+        private void Save(object sender, EventArgs e)
+        {
+            InstallationPath = tbxInstallationPath.Text;
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+        private void Cancel(object sender, EventArgs e)
+        {
+            InstallationPath = null;
+            Close();
+        }
+        private void ShowPathSelector(object sender, EventArgs e)
+        {
+            if (fbdInstallationPath.ShowDialog() == DialogResult.OK)
+                tbxInstallationPath.Text = fbdInstallationPath.SelectedPath;
+        }
+    }
+}

--- a/Library/CommonScripts/View/SetInstallationPathForm.resx
+++ b/Library/CommonScripts/View/SetInstallationPathForm.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
With this change, the app can run properly after Windows startup

- Show a Form if there's no app.config at %appdata% to create one, asking the user for the installationPath. https://github.com/yeray697/CommonScriptsContainer/commit/a39783e283c3c9f26a9719886d2f7aa7b7efd2d1
- Settings were not being saved using the installationPath. Now it is. https://github.com/yeray697/CommonScriptsContainer/commit/c101671d1adf49a0137b3618431c59e02a6f0bf1
- Scripts are now run under the path specified in the installationPath https://github.com/yeray697/CommonScriptsContainer/commit/b04eca4ebafd42ce0d3c8bbb1017c3a193a35031
- Small refactor on AppSettingsManager https://github.com/yeray697/CommonScriptsContainer/commit/e77d7e616c47e2b458b7649da6a7a90ebe5443ab

Close #3 