### PR TITLE
Move logs to %appdata%

### DIFF
--- a/Library/CommonScripts/Logging/LogManager.cs
+++ b/Library/CommonScripts/Logging/LogManager.cs
@@ -2,18 +2,23 @@
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
+using System.IO;
 
 namespace CommonScripts.Logging
 {
     public static class LogManager
     {
-        private const string LOG_PATH = @"logs\CommonScripts.log";
+        private const string LOG_FOLDER = @"logs";
+        private const string LOG_FILE_NAME = @"CommonScripts.log";
         private static LoggingLevelSwitch _levelSwitch;
         private static LogSink _consoleLogSink;
         public static void InstanceLogger()
         {
             _consoleLogSink = new LogSink();
             _levelSwitch = new LoggingLevelSwitch(AppSettingsManager.GetFileMinLogLevel());
+
+            string baseDirectory = AppSettingsManager.GetAppConfigDirectory();
+            CreateLogDirectory(baseDirectory);
             var loggerConfiguration = new LoggerConfiguration()
                 .MinimumLevel.ControlledBy(_levelSwitch)
                 .MinimumLevel.Override("Quartz", LogEventLevel.Warning)
@@ -21,10 +26,16 @@ namespace CommonScripts.Logging
 
             loggerConfiguration
                 .WriteTo.Console()
-                .WriteTo.File(LOG_PATH)
+                .WriteTo.File(Path.Combine(baseDirectory, LOG_FOLDER, LOG_FILE_NAME))
                 .WriteTo.Sink(_consoleLogSink);
 
             Log.Logger = loggerConfiguration.CreateLogger();
+        }
+
+        private static void CreateLogDirectory(string baseDirectory)
+        {
+            if (!Directory.Exists(Path.Combine(baseDirectory, LOG_FOLDER)))
+                Directory.CreateDirectory(Path.Combine(baseDirectory, LOG_FOLDER));
         }
 
         public static void ChangeMinLoggingLevel(LogEventLevel newLogLevel)

--- a/Library/CommonScripts/Settings/AppSettingsManager.cs
+++ b/Library/CommonScripts/Settings/AppSettingsManager.cs
@@ -111,7 +111,7 @@ namespace CommonScripts.Settings
             Directory.CreateDirectory(appConfigDirectory);
             File.WriteAllText(Path.Combine(appConfigDirectory, APP_CONFIG_NAME), GetAppConfigText(installationPath));
         }
-        private static string GetAppConfigDirectory()
+        public static string GetAppConfigDirectory()
         {
             string folder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             return Path.Combine(folder, COMMON_SCRIPTS_FOLDER_NAME);


### PR DESCRIPTION
As logs were being created with a relative path, when the app was launch at Windows startup, they were not created under the app or the %appdata% folder.

Now, they are forced to be created at %appdata%/CommonScripts/logs